### PR TITLE
Fixed archive view headings.

### DIFF
--- a/src/app/archive-widget/archive-widget.component.ts
+++ b/src/app/archive-widget/archive-widget.component.ts
@@ -29,7 +29,7 @@ export class ArchiveComponent extends LoadableComponent {
     }
 
     public apply() {
-        if (!isNullOrUndefined(this.yearInput)) {
+        if (!isNullOrUndefined(this.yearInput) && this.yearInput != '') {
             this.archiveService.applyFilter({year: Number(this.yearInput), month: Number(this.monthInput)});
         }
     }

--- a/src/app/article-grid/article-grid.component.scss
+++ b/src/app/article-grid/article-grid.component.scss
@@ -91,6 +91,7 @@
 
 	h3.article-title {
 		font-weight: bold;
+		font-size: 1rem;
 	}
 
 	time.article-date {

--- a/src/app/article-grid/article-grid.component.ts
+++ b/src/app/article-grid/article-grid.component.ts
@@ -108,6 +108,8 @@ export class ArticleGridComponent extends LoadableComponent {
 
             if (params && Object.keys(params).length !== 0) {
 
+                console.log(params);
+
                 let date = '';
                 let endDate = '';
 
@@ -147,12 +149,12 @@ export class ArticleGridComponent extends LoadableComponent {
                     }
                 }
 
-                if (!isNullOrUndefined(params['date']) && isNullOrUndefined(params['searchTerm'])) {
+                if (date != '' && isNullOrUndefined(params['searchTerm'])) {
                     this.heading = 'Arkiv från <span>' + date + '</span> ';
                     this.heading += 'till <span>' + endDate + '</span> ';
-                } else if (isNullOrUndefined(date) && !isNullOrUndefined(params['searchTerm'])) {
+                } else if (date == '' && !isNullOrUndefined(params['searchTerm'])) {
                     this.heading = 'Sökresultat för <span>' + params['searchTerm'] + '</span>';
-                } else if (!isNullOrUndefined(date) && !isNullOrUndefined(params['searchTerm'])) {
+                } else if (date != '' && !isNullOrUndefined(params['searchTerm'])) {
                     this.heading = 'Sökresultat för <span>' + params['searchTerm'] + '</span> från <span>' + date + '</span> ';
                     this.heading += 'till <span>' + endDate + '</span> ';
                 }


### PR DESCRIPTION
Fixed issue with heading showing empty strings. Article headings size in grid are minimized to accommodate the length of most headings.